### PR TITLE
Use maps instead of objects for begin/end turns

### DIFF
--- a/games/game1-v2.7.0/src/game.test.ts
+++ b/games/game1-v2.7.0/src/game.test.ts
@@ -22,7 +22,7 @@ test("happy path", () => {
   match.makeMove(p0, "roll");
   match.makeMove(p1, "roll");
   match.makeMove(p2, "roll");
-  expect(() => match.makeMove(p1, "roll")).toThrowError("not your turn");
+  expect(() => match.makeMove(p1, "roll")).toThrow("not your turn");
   match.makeMove(p0, "roll");
   match.makeMove(p1, "roll");
 

--- a/packages/dev-server/src/backend.ts
+++ b/packages/dev-server/src/backend.ts
@@ -392,11 +392,11 @@ class Backend extends EventTarget {
     }
 
     // Also cancel move expiry timeouts for users whose turn has ended.
-    for (const userId of Object.keys(result.endTurn)) {
+    for (const userId of result.endTurn.keys()) {
       this._removeDelayedMoveForUser(userId);
     }
 
-    for (const userId of Object.keys(result.beginTurn)) {
+    for (const userId of result.beginTurn.keys()) {
       this._removeDelayedMoveForUser(userId);
     }
 

--- a/packages/game/src/execution.ts
+++ b/packages/game/src/execution.ts
@@ -188,8 +188,8 @@ export function executePlayerMove<GS extends GameStateBase>(
 
   // For expiration moves, if the player's turn was not explicitely begun,
   // it means their turn should end.
-  if (isExpiration && sideEffectResults.beginTurn[userId] === undefined) {
-    sideEffectResults.endTurn[userId] = null;
+  if (isExpiration && !sideEffectResults.beginTurn.has(userId)) {
+    sideEffectResults.endTurn.set(userId, null);
   }
 
   const allPatches: Patch[] = [];
@@ -282,8 +282,8 @@ export function executePlayerMove<GS extends GameStateBase>(
   };
 }
 
-type BeginTurn = Record<UserId, { expiresAt?: number }>;
-type EndTurn = Record<UserId, null>;
+export type BeginTurn = Map<UserId, { expiresAt?: number }>;
+export type EndTurn = Map<UserId, null>;
 
 type SideEffectResults = {
   matchHasEnded: boolean;
@@ -314,8 +314,8 @@ function defineMoveSideEffects<GS extends GameStateBase>({
 }): { sideEffectResults: SideEffectResults; moveSideEffects: MoveSideEffects } {
   const sideEffectResults: SideEffectResults = {
     matchHasEnded: false,
-    beginTurn: {},
-    endTurn: {},
+    beginTurn: new Map(),
+    endTurn: new Map(),
     delayedMoves: [],
     stats: [],
   };
@@ -325,8 +325,8 @@ function defineMoveSideEffects<GS extends GameStateBase>({
   };
 
   const endTurnForUser = (userId: UserId) => {
-    delete sideEffectResults.beginTurn[userId];
-    sideEffectResults.endTurn[userId] = null;
+    sideEffectResults.beginTurn.delete(userId);
+    sideEffectResults.endTurn.set(userId, null);
 
     // Note that this is not very efficient because we need to loop through all
     // delayed moves, and we call this for all users.
@@ -376,8 +376,8 @@ function defineMoveSideEffects<GS extends GameStateBase>({
     }
 
     for (const userId of userIds) {
-      sideEffectResults.beginTurn[userId] = { expiresAt };
-      delete sideEffectResults.endTurn[userId];
+      sideEffectResults.beginTurn.set(userId, { expiresAt });
+      sideEffectResults.endTurn.delete(userId);
     }
 
     return { expiresAt };
@@ -553,7 +553,7 @@ export function updateMetaWithTurnInfo({
     (draft: { meta: Meta }) => {
       const { meta } = draft;
 
-      for (const [userId, { expiresAt }] of Object.entries(beginTurn)) {
+      for (const [userId, { expiresAt }] of beginTurn.entries()) {
         metaBeginTurn({
           meta,
           beginsAt: now,
@@ -562,7 +562,7 @@ export function updateMetaWithTurnInfo({
         });
       }
 
-      for (const userId of Object.keys(endTurn)) {
+      for (const userId of endTurn.keys()) {
         metaEndTurn({
           meta,
           userId,

--- a/packages/game/src/testing.test.ts
+++ b/packages/game/src/testing.test.ts
@@ -606,7 +606,7 @@ test("error in move does not get applied", () => {
 
   expect(() => {
     match.makeMove(userId, "incrementWithError");
-  }).toThrowError("error");
+  }).toThrow("error");
 
   expect(match.board.x).toBe(0);
 });
@@ -637,7 +637,7 @@ test("canFail", () => {
 
   expect(() => {
     match.makeMove(userId, "go", null, { canFail: false });
-  }).toThrowError("error");
+  }).toThrow("error");
 
   expect(match.board.x).toBe(0);
 });

--- a/packages/game/src/testing.ts
+++ b/packages/game/src/testing.ts
@@ -14,7 +14,9 @@ import {
 import { IfAnyNull } from "@lefun/core";
 
 import {
+  BeginTurn,
   DelayedMove,
+  EndTurn,
   executeBoardMove,
   executePlayerMove,
   Stat,
@@ -391,8 +393,8 @@ export class MatchTester<GS extends GameStateBase, G extends Game<GS>> {
     stats,
   }: {
     matchHasEnded: boolean;
-    beginTurn: Record<UserId, { expiresAt?: number }>;
-    endTurn: Record<UserId, null>;
+    beginTurn: BeginTurn;
+    endTurn: EndTurn;
     delayedMoves: DelayedMove[];
     stats: Stat[];
   }) {


### PR DESCRIPTION
Maps are iterated in the order of insertion, whereas objects's key are iterated in a custom order that depends on the keys. In ours case keys are user ids. Having the order not depend on the user ids makes unit testing simpler down the line.